### PR TITLE
Fix flex grid layout of main section and sidebar.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,4 +58,9 @@ module ApplicationHelper
       icon + text
     end
   end
+
+  # The flex-grid styling class to apply to the main <section>.
+  def main_section_width_class
+    content_for?(:sidebar) ? 'small-7' : 'small-10'
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
           <%= render menu_type(current_user, current_course) if current_user %>
         </ul>
       </section>
-      <section id="main">
+      <section class="<%= main_section_width_class %>" id="main">
         <%= yield %>
       </section>
       <% if content_for? :sidebar %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  describe '#main_section_width_class' do
+    before { @view_flow = ActionView::OutputFlow.new }
+
+    it 'returns a 7-column style when the template has a sidebar' do
+      content_for :sidebar, 'sidebar'
+      assert_equal 'small-7', main_section_width_class
+    end
+
+    it 'returns a 10-column style when the template has no sidebar' do
+      assert_nil content_for(:sidebar)
+      assert_equal 'small-10', main_section_width_class
+    end
+  end
+end


### PR DESCRIPTION
The main section of the page should stop getting stacked underneath the menu sidebar.