### PR TITLE
Add back Google Analytics js tag.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <%= stylesheet_link_tag "application" %>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag %>
+    <%= render 'layouts/google_analytics' %>
   </head>
 
   <body class="<%= current_user ? 'user' : 'nouser' %>">


### PR DESCRIPTION
There's an alternative tracking snippet that allows for preloading, and is only recommended if "your visitors primarily use modern browsers to access your site." Would we rather have that snippet?

https://developers.google.com/analytics/devguides/collection/analyticsjs/