### PR TITLE
Add tests for Assignment#can_read_content?

### DIFF
--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -26,13 +26,17 @@ class AssignmentFile < ActiveRecord::Base
   # The course for which this file has been uploaded.
   has_one :course, through: :assignment
 
+  # True if the file's release date has passed.
+  def released?
+    !!released_at && (released_at < Time.current)
+  end
+
   # True if the given user is allowed to see this file.
   #
   # TODO(spark008): Add checks to this and other model permission methods to
   #     ensure that the user is a student registered for the course.
   def can_read?(user)
-    (released_at && (released_at < Time.current) && assignment.released?) ||
-        assignment.can_edit?(user)
+    (released? && assignment.released?) || assignment.can_edit?(user)
   end
 
   # The default release date for a particular resource file.

--- a/test/models/assignment_file_test.rb
+++ b/test/models/assignment_file_test.rb
@@ -32,6 +32,23 @@ class AssignmentFileTest < ActiveSupport::TestCase
     assert @resource.valid?
   end
 
+  describe '#released?' do
+    it 'returns true if the release date has passed' do
+      assert_operator @resource.released_at, :<, Time.current
+      assert_equal true, @resource.released?
+    end
+
+    it 'returns false if the release date is nil' do
+      @resource.released_at = nil
+      assert_equal false, @resource.released?
+    end
+
+    it 'returns false if the release date has not passed' do
+      @resource.released_at = 1.day.from_now
+      assert_equal false, @resource.released?
+    end
+  end
+
   describe '#can_read?' do
     let(:any_user) { User.new }
 


### PR DESCRIPTION
There are 2 failing tests added here. I think adding the exam session start time filter to the `Assignment#can_read_content?` method should fix them.