### PR TITLE
Speed up queries for deliverable dashboard.

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -36,15 +36,12 @@ module SubmissionsHelper
     "#{collaborator.email} (#{collaborator.profile.name})"
   end
 
-  # An icon that links to the given submission's analysis, if one exists.
+  # A <figure> tag displaying the given submission's author and status.
   def submission_figure(submission)
-    analysis = submission.analysis
-    if analysis
-      link_to analysis_path(analysis, course_id: submission.course) do
-        render 'deliverables/submission_figure', submission: submission
-      end
-    else
-      render 'deliverables/submission_figure', submission: submission
+    content_tag :figure, title: submission.subject.name,
+        class: 'submission-figure' do
+      user_image_tag(submission.subject, size: :medium) +
+      analysis_status_badge_tag(submission.analysis)
     end
   end
 end

--- a/app/views/assignments/_deliverable_dashboard.html.erb
+++ b/app/views/assignments/_deliverable_dashboard.html.erb
@@ -1,5 +1,6 @@
-<% submissions = deliverable.submissions.includes(:analysis, :subject).
-                                         order(updated_at: :desc) %>
+<% submissions = deliverable.submissions.
+      includes(:analysis, subject: [:profile, :credentials]).
+      order(updated_at: :desc) %>
 
 <span class="actions">
   <%= button_to reanalyze_deliverable_path(deliverable,
@@ -20,9 +21,8 @@
 <div data-pwnfx-scope="submissions-list"
      data-pwnfx-delayed-target="submission-states">
   <ol class="submission-list no-bullet">
-    <% submissions.each do |submission| %>
-      <li class="submission-list-entry"><%= submission_figure submission %></li>
-    <% end %>
+    <%= render partial: 'deliverables/submission_figure',
+          collection: submissions, as: :submission %>
     <% if submissions.any? { |s| s.analysis && s.analysis.status_will_change? } %>
       <%= content_tag :li, ajax_loading_icon_tag, data: {
            pwnfx_delayed: 'submission-states', pwnfx_delayed_method: 'GET',

--- a/app/views/deliverables/_submission_figure.html.erb
+++ b/app/views/deliverables/_submission_figure.html.erb
@@ -1,4 +1,8 @@
-<figure title="<%= submission.subject.name %>" class="submission-figure">
-  <%= user_image_tag submission.subject, size: :medium %>
-  <%= analysis_status_badge_tag submission.analysis %>
-</figure>
+<li class="submission-list-entry">
+<% if submission.analysis %>
+  <%= link_to submission_figure(submission), analysis_path(submission.analysis,
+        course_id: submission.course) %>
+<% else %>
+  <%= submission_figure submission %>
+<% end %>
+</li>

--- a/test/helpers/submissions_helper_test.rb
+++ b/test/helpers/submissions_helper_test.rb
@@ -45,13 +45,10 @@ class SubmissionsHelperTest < ActionView::TestCase
   describe '#submission_figure' do
     describe 'the submission has an analysis' do
       before { assert_not_nil analysis }
-      let(:url) { analysis_path(analysis, course_id: analysis.course) }
 
-      it 'renders the submission figure inside a link to the analysis' do
+      it 'renders the submission figure' do
         rendered_buffer = render text: submission_figure(submission)
-        assert_select 'a[href=?]', url, true, rendered_buffer do
-          assert_select 'figure'
-        end
+        assert_select 'figure', true, rendered_buffer
       end
     end
 


### PR DESCRIPTION
For seed data:
Loading time before: 1279ms (1170.8ms Views, 69.4ms ActiveRecord)
Loading time now: 997ms (927.5ms Views, 31.3ms ActiveRecord)

Not a lot, but it's something. The `assignments/_deliverable_dashboard` partial on its own goes from 450.4ms to 239.3ms.