### PR TITLE
Speed up queries for recitation dashboard.

### DIFF
--- a/app/models/assignment_metric.rb
+++ b/app/models/assignment_metric.rb
@@ -83,8 +83,7 @@ class AssignmentMetric < ApplicationRecord
     students_with_grades = 0
 
     recitation.users.each do |user|
-      next if user.admin?
-
+      # NOTE: Grades should only exist for student submissions.
       grade = grade_for(user)
       next if grade.score.nil?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,7 +176,7 @@ class User
 
   # The user's recitation section for the given course.
   def recitation_section_for(course)
-    recitation_sections.where(course: course).first
+    recitation_sections.find_by course: course
   end
 
   # True if the user is a registered student in the given course.

--- a/app/views/assignments/_recitations_dashboard.html.erb
+++ b/app/views/assignments/_recitations_dashboard.html.erb
@@ -10,7 +10,7 @@
         <%= recitation_score_meter_tag assignment, section %>
       </span>
       <span class="high-precision stats-summary">
-        <%= average_score_fraction_tag(assignment, section) %>
+        <%= average_score_fraction_tag assignment, section %>
       </span>
     </li>
   <% end %>


### PR DESCRIPTION
Not checking whether the grade belongs to an admin cuts down 379 SQL queries to 289 SQL queries.