### PR TITLE
Speed up queries for average recitation score.

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -251,8 +251,7 @@ class Assignment
   # This is the sum of all the weighted metrics' recitation averaged scores. It
   # should be divided by a weighted max score to calculate a percentage.
   def recitation_score(recitation)
-    return nil if metrics.empty?
-    metrics.sum { |m| m.grade_for_recitation(recitation) * m.weight }
+    metrics.sum { |m| recitation.average_metric_score(m) * m.weight }
   end
 end
 

--- a/app/models/assignment_metric.rb
+++ b/app/models/assignment_metric.rb
@@ -77,23 +77,6 @@ class AssignmentMetric < ApplicationRecord
     Grade.new metric: self, course: course, subject: subject
   end
 
-  # The average grade dispensed in the given recitation for this metric.
-  def grade_for_recitation(recitation)
-    grade_total = 0
-    students_with_grades = 0
-
-    recitation.users.each do |user|
-      # NOTE: Grades should only exist for student submissions.
-      grade = grade_for(user)
-      next if grade.score.nil?
-
-      grade_total += grade.score
-      students_with_grades += 1
-    end
-
-    students_with_grades == 0 ? 0 : grade_total / students_with_grades
-  end
-
   # Number of grades that will be posted for this metric.
   #
   # The estimation is based on the number of students in the class.

--- a/app/models/recitation_section.rb
+++ b/app/models/recitation_section.rb
@@ -43,4 +43,16 @@ class RecitationSection < ApplicationRecord
 
   # Proposed assignments of students to this recitation section.
   has_many :recitation_assignments
+
+  # The average grade assigned for the given metric in this section.
+  #
+  # Students who do not have a grade are excluded from the calculation.
+  #
+  # @param [AssignmentMetric] metric the assessed metric
+  # @return [Float] the average grade; 0 if there are no students in the
+  #   section, or none of the students have grades for this metric
+  def average_metric_score(metric)
+    users.includes(:direct_grades).where(grades: { metric_id: metric.id }).
+        average(:score) || 0
+  end
 end

--- a/test/fixtures/grades.yml
+++ b/test/fixtures/grades.yml
@@ -14,7 +14,8 @@
 #
 
 # NOTE: Do not create grades for the following:
-#   { metric: ps3_p1 } (or any metric that belongs to assignments(:ps3))
+#   { metric: ps3_p1 } (or any metric that belongs to assignments(:ps3)),
+#   { metric: assessment_overall, subject: mandark (User) }
 
 awesome_ps1_p1:
   metric: ps1_p1

--- a/test/helpers/assignments_helper_test.rb
+++ b/test/helpers/assignments_helper_test.rb
@@ -201,24 +201,35 @@ class AssignmentsHelperTest < ActionView::TestCase
   end
 
   describe '#recitation_score_meter_tag' do
-    it 'returns a blank string if the assignment has no metrics' do
+    let(:section) { recitation_sections(:r01) }
+
+    it 'returns an empty meter if the assignment has no metrics' do
       assert_empty unreleased_exam.metrics
-      assert_equal '', recitation_score_meter_tag(unreleased_exam,
-                                                  recitation_sections(:r01))
+      render text: recitation_score_meter_tag(unreleased_exam, section)
+      assert_select "span.progress-meter:match('style', ?)", /width: 0.00%;/
     end
 
     it 'returns an empty meter for assignments with metrics, but no grades' do
       assert_not_empty grades_unreleased_assignment.metrics
       assert_empty grades_unreleased_assignment.grades
       render text: recitation_score_meter_tag(grades_unreleased_assignment,
-                                              recitation_sections(:r01))
+                                              section)
+      assert_select "span.progress-meter:match('style', ?)", /width: 0.00%;/
+    end
+
+    it 'returns an empty meter for recitation sections with no students' do
+      section.users.each do |u|
+        u.registration_for(section.course).update! recitation_section: nil
+      end
+      render text: recitation_score_meter_tag(grades_unreleased_assignment,
+                                              section)
       assert_select "span.progress-meter:match('style', ?)", /width: 0.00%;/
     end
 
     it 'returns a meter with the average recitation score' do
-      html_text = recitation_score_meter_tag(many_metrics_assignment,
-                                             recitation_sections(:r01))
-      render text: html_text
+      html_text = recitation_score_meter_tag(many_metrics_assignment, section)
+      html = render text: html_text
+      puts html
       assert_select "span.progress-meter:match('style', ?)", /width: 40.00%;/
     end
   end

--- a/test/models/assignment_metric_test.rb
+++ b/test/models/assignment_metric_test.rb
@@ -80,28 +80,6 @@ class AssignmentMetricTest < ActiveSupport::TestCase
     end
   end
 
-  describe '#grade_for_recitation' do
-    let(:dexter_solo_section) { recitation_sections(:r01) }
-    let(:deedee_section) { recitation_sections(:r02) }
-
-    it 'returns the average score for students in the given recitation only' do
-      assert_equal 10, quality_metric.grade_for_recitation(deedee_section)
-    end
-
-    it 'returns 0 if none of the students in the recitation has a grade' do
-      Grade.where(subject: deedee_section.users, metric: quality_metric).
-            destroy_all
-      assert_equal 0, quality_metric.grade_for_recitation(deedee_section)
-    end
-
-    it 'accounts only for students who have a grade' do
-      grades(:dexter_assessment_quality).destroy
-      assert_not_equal Grade.where(subject: dexter_solo_section.users,
-          metric: quality_metric).count, dexter_solo_section.users.length
-      assert_equal 3, quality_metric.grade_for_recitation(dexter_solo_section)
-    end
-  end
-
   describe 'score calculations' do
     describe 'AverageScore concern' do
       describe '#average_score_percentage' do

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -1262,9 +1262,17 @@ class AssignmentTest < ActiveSupport::TestCase
         assert_equal 40, assignment.recitation_score(section)
       end
 
-      it 'returns nil if the assignment has no metrics' do
+      it 'returns 0 if the assignment has no metrics' do
         assignment.metrics.destroy_all
-        assert_nil assignment.reload.recitation_score(section)
+        assert_equal 0, assignment.reload.recitation_score(section)
+      end
+
+      it 'returns 0 if the recitation section has no students' do
+        section.users.each do |u|
+          u.registration_for(section.course).update! recitation_section: nil
+        end
+        section.users.reload
+        assert_equal 0, assignment.recitation_score(section)
       end
 
       # TODO(spark008): Write test for team assignments.

--- a/test/models/recitation_section_test.rb
+++ b/test/models/recitation_section_test.rb
@@ -60,4 +60,46 @@ class RecitationSectionTest < ActiveSupport::TestCase
       @recitation.update! params
     end
   end
+
+  describe '#average_metric_score' do
+    let(:metric) { assignment_metrics(:assessment_overall) }
+    let(:gradeless_user) { users(:mandark) }
+
+    describe 'some students in the section have no grades' do
+      before do
+        gradeless_user.registration_for(courses(:main)).update!(
+            recitation_section: recitation)
+        assert_empty metric.grades.where(subject: gradeless_user)
+      end
+
+      it 'returns the average student score for the given metric only, excluding
+          students without grades' do
+        assert_equal 3, recitation.users.count
+        assert_equal 3, metric.grades.count
+        assert_equal 2, metric.grades.where(subject: recitation.users).count
+        assert_equal (70 + 10) / 2.0, recitation.average_metric_score(metric)
+      end
+    end
+
+    describe 'none of the students in the section have grades' do
+      before { metric.grades.where(subject: recitation.users).destroy_all }
+
+      it 'returns 0' do
+        assert_equal 0, recitation.average_metric_score(metric)
+      end
+    end
+
+    describe 'the section has no students' do
+      before do
+        recitation.users.each do |u|
+          u.registration_for(courses(:main)).update!(recitation_section: nil)
+        end
+        recitation.users.reload
+      end
+
+      it 'returns 0' do
+        assert_equal 0, recitation.average_metric_score(metric)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Testing results on seed data:
* Sped up from 1034.6ms for **289** SQL queries, to 196.3ms for **32** SQL queries.
* The total page load went from **2189ms** down to **1267ms**